### PR TITLE
Added specific observables for each MouseListener event

### DIFF
--- a/src/main/java/rx/observables/SwingObservable.java
+++ b/src/main/java/rx/observables/SwingObservable.java
@@ -98,6 +98,61 @@ public enum SwingObservable { ; // no instances
     }
 
     /**
+     * Creates an observable corresponding to mouse clicked events.
+     *
+     * @param component
+     *            The component to register the observable for.
+     * @return Observable of mouse events.
+     */
+    public static Observable<MouseEvent> fromMouseClickedEvents(Component component) {
+        return MouseEventSource.fromMouseClickedEventsOf(component);
+    }
+
+    /**
+     * Creates an observable corresponding to mouse pressed events
+     *
+     * @param component
+     *            The component to register the observable for.
+     * @return Observable of mouse events.
+     */
+    public static Observable<MouseEvent> fromMousePressedEvents(Component component) {
+        return MouseEventSource.fromMousePressedEventsOf(component);
+    }
+
+    /**
+     * Creates an observable corresponding to mouse released events.
+     *
+     * @param component
+     *            The component to register the observable for.
+     * @return Observable of mouse events.
+     */
+    public static Observable<MouseEvent> fromMouseReleasedEvents(Component component) {
+        return MouseEventSource.fromMouseReleasedEventsOf(component);
+    }
+
+    /**
+     * Creates an observable corresponding to mouse entered events.
+     *
+     * @param component
+     *            The component to register the observable for.
+     * @return Observable of mouse events.
+     */
+    public static Observable<MouseEvent> fromMouseEnteredEvents(Component component) {
+        return MouseEventSource.fromMouseEnteredEventsOf(component);
+    }
+
+    /**
+     * Creates an observable corresponding to mouse exited events.
+     *
+     * @param component
+     *            The component to register the observable for.
+     * @return Observable of mouse events.
+     */
+    public static Observable<MouseEvent> fromMouseExitedEvents(Component component) {
+        return MouseEventSource.fromMouseExitedEventsOf(component);
+    }
+
+    /**
      * Creates an observable corresponding to raw mouse motion events.
      * 
      * @param component

--- a/src/main/java/rx/swing/sources/MouseEventSource.java
+++ b/src/main/java/rx/swing/sources/MouseEventSource.java
@@ -77,6 +77,136 @@ public enum MouseEventSource {
     }
 
     /**
+     * @see rx.observables.SwingObservable#fromMouseClickedEvents
+     */
+    public static Observable<MouseEvent> fromMouseClickedEventsOf(final Component component) {
+        return Observable.create(new OnSubscribe<MouseEvent>() {
+            @Override
+            public void call(final Subscriber<? super MouseEvent> subscriber) {
+                SwingObservable.assertEventDispatchThread();
+                final MouseListener listener = new MouseAdapter() {
+                    @Override
+                    public void mouseClicked(MouseEvent event) {
+                        subscriber.onNext(event);
+                    }
+                };
+                component.addMouseListener(listener);
+
+                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                    @Override
+                    public void call() {
+                        component.removeMouseListener(listener);
+                    }
+                }));
+            }
+        });
+    }
+
+    /**
+     * @see rx.observables.SwingObservable#fromMousePressedEvents
+     */
+    public static Observable<MouseEvent> fromMousePressedEventsOf(final Component component) {
+        return Observable.create(new OnSubscribe<MouseEvent>() {
+            @Override
+            public void call(final Subscriber<? super MouseEvent> subscriber) {
+                SwingObservable.assertEventDispatchThread();
+                final MouseListener listener = new MouseAdapter() {
+                    @Override
+                    public void mousePressed(MouseEvent event) {
+                        subscriber.onNext(event);
+                    }
+                };
+                component.addMouseListener(listener);
+
+                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                    @Override
+                    public void call() {
+                        component.removeMouseListener(listener);
+                    }
+                }));
+            }
+        });
+    }
+
+    /**
+     * @see rx.observables.SwingObservable#fromMouseReleasedEvents
+     */
+    public static Observable<MouseEvent> fromMouseReleasedEventsOf(final Component component) {
+        return Observable.create(new OnSubscribe<MouseEvent>() {
+            @Override
+            public void call(final Subscriber<? super MouseEvent> subscriber) {
+                SwingObservable.assertEventDispatchThread();
+                final MouseListener listener = new MouseAdapter() {
+                    @Override
+                    public void mouseReleased(MouseEvent event) {
+                        subscriber.onNext(event);
+                    }
+                };
+                component.addMouseListener(listener);
+
+                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                    @Override
+                    public void call() {
+                        component.removeMouseListener(listener);
+                    }
+                }));
+            }
+        });
+    }
+
+    /**
+     * @see rx.observables.SwingObservable#fromMouseEnteredEvents
+     */
+    public static Observable<MouseEvent> fromMouseEnteredEventsOf(final Component component) {
+        return Observable.create(new OnSubscribe<MouseEvent>() {
+            @Override
+            public void call(final Subscriber<? super MouseEvent> subscriber) {
+                SwingObservable.assertEventDispatchThread();
+                final MouseListener listener = new MouseAdapter() {
+                    @Override
+                    public void mouseEntered(MouseEvent event) {
+                        subscriber.onNext(event);
+                    }
+                };
+                component.addMouseListener(listener);
+
+                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                    @Override
+                    public void call() {
+                        component.removeMouseListener(listener);
+                    }
+                }));
+            }
+        });
+    }
+
+    /**
+     * @see rx.observables.SwingObservable#fromMouseExitedEvents
+     */
+    public static Observable<MouseEvent> fromMouseExitedEventsOf(final Component component) {
+        return Observable.create(new OnSubscribe<MouseEvent>() {
+            @Override
+            public void call(final Subscriber<? super MouseEvent> subscriber) {
+                SwingObservable.assertEventDispatchThread();
+                final MouseListener listener = new MouseAdapter() {
+                    @Override
+                    public void mouseExited(MouseEvent event) {
+                        subscriber.onNext(event);
+                    }
+                };
+                component.addMouseListener(listener);
+
+                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                    @Override
+                    public void call() {
+                        component.removeMouseListener(listener);
+                    }
+                }));
+            }
+        });
+    }
+
+    /**
      * @see rx.observables.SwingObservable#fromMouseMotionEvents
      */
     public static Observable<MouseEvent> fromMouseMotionEventsOf(final Component component) {


### PR DESCRIPTION
I propose that we add ways to create observables for each type MouseListener event. So we'd have a separate calls for "fromMouseClicked", "fromMousePressed", etc. This is one of the first things new users look for, in my experience.

Of course, users can just filter raw MouseEvents, but I think that gets redundant pretty quickly. 

Here's a "mouse-drag-position" observable that shows the benefits of the new calls:

``` java
Observable<MouseEvent> leftMouseBtnDown =
        SwingObservable.fromMousePressedEvents(comp)
        .filter(e -> SwingUtilities.isLeftMouseButton(e));

Observable<MouseEvent> leftMouseBtnRelease =
        SwingObservable.fromMouseReleasedEvents(comp)
        .filter(e -> SwingUtilities.isLeftMouseButton(e));

Observable<Point> mouseDragPositions =
        SwingObservable.fromMouseMotionEvents(comp)
        .skipUntil(leftMouseBtnDown)
        .takeUntil(leftMouseBtnRelease)
        .map(e -> e.getPoint());
```

Thoughts?
