### PR TITLE
Added Observable support for Item Events.

### DIFF
--- a/src/main/java/rx/observables/SwingObservable.java
+++ b/src/main/java/rx/observables/SwingObservable.java
@@ -15,13 +15,17 @@
  */
 package rx.observables;
 
-import static rx.swing.sources.ItemEventSource.Predicate.SELECTED;
-
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.ItemSelectable;
 import java.awt.Point;
-import java.awt.event.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ComponentEvent;
+import java.awt.event.FocusEvent;
+import java.awt.event.ItemEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseWheelEvent;
 import java.util.Set;
 
 import javax.swing.AbstractButton;
@@ -184,8 +188,13 @@ public enum SwingObservable { ; // no instances
      *            The ItemSelectable to register the observable for.
      * @return Observable emitting the an item event whenever the given itemSelectable is selected.
      */
-    public static Observable<ItemEvent> fromSelectionEvents(ItemSelectable itemSelectable) {
-        return ItemEventSource.fromItemEventsOf( itemSelectable ).filter( SELECTED );
+    public static Observable<ItemEvent> fromItemSelectionEvents(ItemSelectable itemSelectable) {
+        return ItemEventSource.fromItemEventsOf(itemSelectable).filter(new Func1<ItemEvent, Boolean>() {
+            @Override
+            public Boolean call(ItemEvent event) {
+                return event.getStateChange() == ItemEvent.SELECTED;
+            }
+        });
     }
     
     /**
@@ -195,8 +204,13 @@ public enum SwingObservable { ; // no instances
      *            The ItemSelectable to register the observable for.
      * @return Observable emitting the an item event whenever the given itemSelectable is deselected.
      */
-    public static Observable<ItemEvent> fromDeselectionEvents(ItemSelectable itemSelectable) {
-        return ItemEventSource.fromItemEventsOf( itemSelectable ).filter( SELECTED );
+    public static Observable<ItemEvent> fromItemDeselectionEvents(ItemSelectable itemSelectable) {
+        return ItemEventSource.fromItemEventsOf(itemSelectable).filter(new Func1<ItemEvent, Boolean>() {
+            @Override
+            public Boolean call(ItemEvent event) {
+                return event.getStateChange() == ItemEvent.DESELECTED;
+            }
+        });
     }
     
     

--- a/src/main/java/rx/observables/SwingObservable.java
+++ b/src/main/java/rx/observables/SwingObservable.java
@@ -15,8 +15,11 @@
  */
 package rx.observables;
 
+import static rx.swing.sources.ItemEventSource.Predicate.SELECTED;
+
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.ItemSelectable;
 import java.awt.Point;
 import java.awt.event.*;
 import java.util.Set;
@@ -28,9 +31,10 @@ import rx.Observable;
 import rx.functions.Func1;
 import rx.swing.sources.AbstractButtonSource;
 import rx.swing.sources.ComponentEventSource;
+import rx.swing.sources.FocusEventSource;
+import rx.swing.sources.ItemEventSource;
 import rx.swing.sources.KeyEventSource;
 import rx.swing.sources.MouseEventSource;
-import rx.swing.sources.FocusEventSource;
 
 /**
  * Allows creating observables from various sources specific to Swing. 
@@ -162,6 +166,40 @@ public enum SwingObservable { ; // no instances
         return ComponentEventSource.fromResizing(component);
     }
 
+    /**
+     * Creates an observable corresponding to item events.
+     * 
+     * @param component
+     *            The ItemSelectable to register the observable for.
+     * @return Observable emitting the item events for the given itemSelectable.
+     */
+    public static Observable<ItemEvent> fromItemEvents(ItemSelectable itemSelectable) {
+        return ItemEventSource.fromItemEventsOf( itemSelectable );
+    }
+    
+    /**
+     * Creates an observable corresponding to item selection events.
+     * 
+     * @param component
+     *            The ItemSelectable to register the observable for.
+     * @return Observable emitting the an item event whenever the given itemSelectable is selected.
+     */
+    public static Observable<ItemEvent> fromSelectionEvents(ItemSelectable itemSelectable) {
+        return ItemEventSource.fromItemEventsOf( itemSelectable ).filter( SELECTED );
+    }
+    
+    /**
+     * Creates an observable corresponding to item deselection events.
+     * 
+     * @param component
+     *            The ItemSelectable to register the observable for.
+     * @return Observable emitting the an item event whenever the given itemSelectable is deselected.
+     */
+    public static Observable<ItemEvent> fromDeselectionEvents(ItemSelectable itemSelectable) {
+        return ItemEventSource.fromItemEventsOf( itemSelectable ).filter( SELECTED );
+    }
+    
+    
     /**
      * Check if the current thead is the event dispatch thread.
      * 

--- a/src/main/java/rx/swing/sources/ItemEventSource.java
+++ b/src/main/java/rx/swing/sources/ItemEventSource.java
@@ -1,0 +1,59 @@
+package rx.swing.sources;
+
+import java.awt.ItemSelectable;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
+
+import rx.Observable;
+import rx.Observable.OnSubscribe;
+import rx.Subscriber;
+import rx.functions.Action0;
+import rx.functions.Func1;
+import rx.observables.SwingObservable;
+import rx.subscriptions.SwingSubscriptions;
+
+public enum ItemEventSource { ; // no instances
+
+    public static Observable<ItemEvent> fromItemEventsOf(final ItemSelectable itemSelectable) {
+        return Observable.create(new OnSubscribe<ItemEvent>() {
+            @Override
+            public void call(final Subscriber<? super ItemEvent> subscriber) {
+                SwingObservable.assertEventDispatchThread();
+                final ItemListener listener = new ItemListener()
+                {
+                    @Override
+                    public void itemStateChanged( ItemEvent event )
+                    {
+                        subscriber.onNext(event);
+                    }
+                };
+                itemSelectable.addItemListener(listener);
+                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                    @Override
+                    public void call() {
+                        itemSelectable.removeItemListener(listener);
+                    }
+                }));
+            }
+        });
+    }
+    
+    /**
+     * Predicates that help with filtering observables for specific item events.
+     */
+    public enum Predicate implements Func1<ItemEvent, Boolean> {
+        SELECTED(ItemEvent.SELECTED),
+        DESELECTED(ItemEvent.DESELECTED);
+
+        private final int id;
+
+        private Predicate(int id) {
+            this.id = id;
+        }
+
+        @Override
+        public Boolean call(ItemEvent event) {
+            return event.getStateChange() == id;
+        }
+    }
+}

--- a/src/main/java/rx/swing/sources/ItemEventSource.java
+++ b/src/main/java/rx/swing/sources/ItemEventSource.java
@@ -8,7 +8,6 @@ import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Action0;
-import rx.functions.Func1;
 import rx.observables.SwingObservable;
 import rx.subscriptions.SwingSubscriptions;
 
@@ -36,24 +35,5 @@ public enum ItemEventSource { ; // no instances
                 }));
             }
         });
-    }
-    
-    /**
-     * Predicates that help with filtering observables for specific item events.
-     */
-    public enum Predicate implements Func1<ItemEvent, Boolean> {
-        SELECTED(ItemEvent.SELECTED),
-        DESELECTED(ItemEvent.DESELECTED);
-
-        private final int id;
-
-        private Predicate(int id) {
-            this.id = id;
-        }
-
-        @Override
-        public Boolean call(ItemEvent event) {
-            return event.getStateChange() == id;
-        }
     }
 }

--- a/src/test/java/rx/swing/sources/ItemEventSourceTest.java
+++ b/src/test/java/rx/swing/sources/ItemEventSourceTest.java
@@ -1,0 +1,204 @@
+package rx.swing.sources;
+
+import static java.awt.event.ItemEvent.DESELECTED;
+import static java.awt.event.ItemEvent.SELECTED;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.awt.event.ItemEvent;
+
+import javax.swing.AbstractButton;
+
+import org.hamcrest.Matcher;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+
+import rx.Subscription;
+import rx.functions.Action0;
+import rx.functions.Action1;
+import rx.swing.sources.ItemEventSource.Predicate;
+
+public class ItemEventSourceTest
+{
+    @Test
+    public void testObservingItemEvents() throws Throwable {
+        SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+            @Override
+            public void call() {
+                @SuppressWarnings("unchecked")
+                Action1<ItemEvent> action = mock(Action1.class);
+                @SuppressWarnings("unchecked")
+                Action1<Throwable> error = mock(Action1.class);
+                Action0 complete = mock(Action0.class);
+                
+                @SuppressWarnings("serial")
+                class TestButton extends AbstractButton {
+                    
+                    void testSelection() {
+                        fireItemStateChanged(new ItemEvent(this, 
+                                                           ItemEvent.ITEM_STATE_CHANGED, 
+                                                           this, 
+                                                           ItemEvent.SELECTED));
+                    }
+                    void testDeselection() {
+                        fireItemStateChanged(new ItemEvent(this, 
+                                                           ItemEvent.ITEM_STATE_CHANGED, 
+                                                           this, 
+                                                           ItemEvent.DESELECTED));
+                    }
+                }
+
+                TestButton button = new TestButton();
+                Subscription sub = ItemEventSource.fromItemEventsOf(button).subscribe(action,
+                        error, complete);
+
+                verify(action, never()).call(Matchers.<ItemEvent> any());
+                verify(error, never()).call(Matchers.<Throwable> any());
+                verify(complete, never()).call();
+
+                button.testSelection();
+                verify(action, times(1)).call(Mockito.<ItemEvent>argThat(itemEventMatcher(SELECTED)));
+
+                button.testSelection();
+                verify(action, times(2)).call(Mockito.<ItemEvent>argThat(itemEventMatcher(SELECTED)));
+                
+                button.testDeselection();
+                verify(action, times(1)).call(Mockito.<ItemEvent>argThat(itemEventMatcher(DESELECTED)));
+
+
+                sub.unsubscribe();
+                button.testSelection();
+                verify(action, times(2)).call(Mockito.<ItemEvent>argThat(itemEventMatcher(SELECTED)));
+                verify(action, times(1)).call(Mockito.<ItemEvent>argThat(itemEventMatcher(DESELECTED)));
+                verify(error, never()).call(Matchers.<Throwable> any());
+                verify(complete, never()).call();
+            }
+        }).awaitTerminal();
+    }
+    
+    @Test
+    public void testObservingItemEventsFilteredBySelected() throws Throwable {
+        SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+            @Override
+            public void call() {
+                @SuppressWarnings("unchecked")
+                Action1<ItemEvent> action = mock(Action1.class);
+                @SuppressWarnings("unchecked")
+                Action1<Throwable> error = mock(Action1.class);
+                Action0 complete = mock(Action0.class);
+                
+                @SuppressWarnings("serial")
+                class TestButton extends AbstractButton {
+                    void testSelection() {
+                        fireItemStateChanged(new ItemEvent(this, 
+                                                           ItemEvent.ITEM_STATE_CHANGED, 
+                                                           this, 
+                                                           ItemEvent.SELECTED));
+                    }
+                    void testDeselection() {
+                        fireItemStateChanged(new ItemEvent(this, 
+                                                           ItemEvent.ITEM_STATE_CHANGED, 
+                                                           this, 
+                                                           ItemEvent.DESELECTED));
+                    }
+                }
+
+                TestButton button = new TestButton();
+                Subscription sub = ItemEventSource.fromItemEventsOf(button)
+                                                  .filter( Predicate.SELECTED )
+                                                  .subscribe(action, error, complete);
+
+                verify(action, never()).call(Matchers.<ItemEvent> any());
+                verify(error, never()).call(Matchers.<Throwable> any());
+                verify(complete, never()).call();
+
+                button.testSelection();
+                verify(action, times(1)).call(Mockito.<ItemEvent>argThat(itemEventMatcher(SELECTED)));
+                
+                button.testDeselection();
+                verify(action, never()).call(Mockito.<ItemEvent>argThat(itemEventMatcher(DESELECTED)));
+
+
+                sub.unsubscribe();
+                button.testSelection();
+                verify(action, times(1)).call(Mockito.<ItemEvent>argThat(itemEventMatcher(SELECTED)));
+                verify(action, never()).call(Mockito.<ItemEvent>argThat(itemEventMatcher(DESELECTED)));
+                verify(error, never()).call(Matchers.<Throwable> any());
+                verify(complete, never()).call();
+            }
+        }).awaitTerminal();
+    }
+    
+    @Test
+    public void testObservingItemEventsFilteredByDeSelected() throws Throwable {
+        SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+            @Override
+            public void call() {
+                @SuppressWarnings("unchecked")
+                Action1<ItemEvent> action = mock(Action1.class);
+                @SuppressWarnings("unchecked")
+                Action1<Throwable> error = mock(Action1.class);
+                Action0 complete = mock(Action0.class);
+                
+                @SuppressWarnings("serial")
+                class TestButton extends AbstractButton {
+                    void testSelection() {
+                        fireItemStateChanged(new ItemEvent(this, 
+                                                           ItemEvent.ITEM_STATE_CHANGED, 
+                                                           this, 
+                                                           ItemEvent.SELECTED));
+                    }
+                    void testDeselection() {
+                        fireItemStateChanged(new ItemEvent(this, 
+                                                           ItemEvent.ITEM_STATE_CHANGED, 
+                                                           this, 
+                                                           ItemEvent.DESELECTED));
+                    }
+                }
+
+                TestButton button = new TestButton();
+                Subscription sub = ItemEventSource.fromItemEventsOf(button)
+                                                  .filter(Predicate.DESELECTED)
+                                                  .subscribe(action, error, complete);
+
+                verify(action, never()).call(Matchers.<ItemEvent> any());
+                verify(error, never()).call(Matchers.<Throwable> any());
+                verify(complete, never()).call();
+
+                button.testSelection();
+                verify(action, never()).call(Mockito.<ItemEvent>argThat(itemEventMatcher(SELECTED)));
+                
+                button.testDeselection();
+                verify(action, times(1)).call(Mockito.<ItemEvent>argThat(itemEventMatcher(DESELECTED)));
+
+
+                sub.unsubscribe();
+                button.testSelection();
+                verify(action, never()).call(Mockito.<ItemEvent>argThat(itemEventMatcher(SELECTED)));
+                verify(action, times(1)).call(Mockito.<ItemEvent>argThat(itemEventMatcher(DESELECTED)));
+                verify(error, never()).call(Matchers.<Throwable> any());
+                verify(complete, never()).call();
+            }
+        }).awaitTerminal();
+    }
+    
+    private Matcher<ItemEvent> itemEventMatcher(final int eventType)
+    {
+        return new ArgumentMatcher<ItemEvent>() {
+            @Override
+            public boolean matches(Object argument) {
+                if (argument.getClass() !=  ItemEvent.class)
+                    return false;
+                
+                return ((ItemEvent) argument).getStateChange() == eventType;
+            }
+        };
+    }
+}

--- a/src/test/java/rx/swing/sources/ItemEventSourceTest.java
+++ b/src/test/java/rx/swing/sources/ItemEventSourceTest.java
@@ -20,7 +20,7 @@ import org.mockito.Mockito;
 import rx.Subscription;
 import rx.functions.Action0;
 import rx.functions.Action1;
-import rx.swing.sources.ItemEventSource.Predicate;
+import rx.observables.SwingObservable;
 
 public class ItemEventSourceTest
 {
@@ -110,8 +110,7 @@ public class ItemEventSourceTest
                 }
 
                 TestButton button = new TestButton();
-                Subscription sub = ItemEventSource.fromItemEventsOf(button)
-                                                  .filter( Predicate.SELECTED )
+                Subscription sub = SwingObservable.fromItemSelectionEvents(button)
                                                   .subscribe(action, error, complete);
 
                 verify(action, never()).call(Matchers.<ItemEvent> any());
@@ -164,8 +163,7 @@ public class ItemEventSourceTest
                 }
 
                 TestButton button = new TestButton();
-                Subscription sub = ItemEventSource.fromItemEventsOf(button)
-                                                  .filter(Predicate.DESELECTED)
+                Subscription sub = SwingObservable.fromItemDeselectionEvents(button)
                                                   .subscribe(action, error, complete);
 
                 verify(action, never()).call(Matchers.<ItemEvent> any());


### PR DESCRIPTION
Hey I'm very interested in contributing to this project. Here I'm just adding a new source for Item Events.

I added a couple of convenience methods, beyond the standard "from ... bla, bla, bla ... Events" in SwingObservable, for filtering ItemEvents by Selected or Deselected. If this goes against convention or style, let me know.

Cheers,

Mike
