### PR TITLE
Removed SwingScheduler's invokeLater when called from EDT

### DIFF
--- a/src/main/java/rx/schedulers/SwingScheduler.java
+++ b/src/main/java/rx/schedulers/SwingScheduler.java
@@ -33,9 +33,10 @@ import rx.subscriptions.Subscriptions;
  * Executes work on the Swing UI thread.
  * This scheduler should only be used with actions that execute quickly.
  *
- * Note that if an action is scheduled without from the Swing UI thread without
- * a delay from the Swing UI thread, it will not be enqueued on the Swing UI
- * thread, and will instead be ran immediately.
+ * If the calling thread is the Swing UI thread, and no delay parameter is
+ * provided, the action will run immediately. Otherwise, if the calling
+ * thread is NOT the Swing UI thread, the action will be deferred until
+ * all pending UI events have been processed.
  */
 public final class SwingScheduler extends Scheduler {
     private static final SwingScheduler INSTANCE = new SwingScheduler();

--- a/src/test/java/rx/schedulers/SwingSchedulerTest.java
+++ b/src/test/java/rx/schedulers/SwingSchedulerTest.java
@@ -140,11 +140,11 @@ public final class SwingSchedulerTest {
         waitForEmptyEventQueue();
 
         inOrder.verify(thirdStepStart, times(1)).call();
-        inOrder.verify(thirdStepEnd, times(1)).call();
         inOrder.verify(secondStepStart, times(1)).call();
-        inOrder.verify(secondStepEnd, times(1)).call();
         inOrder.verify(firstStepStart, times(1)).call();
         inOrder.verify(firstStepEnd, times(1)).call();
+        inOrder.verify(secondStepEnd, times(1)).call();
+        inOrder.verify(thirdStepEnd, times(1)).call();
     }
 
     private static void waitForEmptyEventQueue() throws Exception {


### PR DESCRIPTION
The `SwingScheduler` will no longer call `invokeLater` when the calling thread is the EDT. Therefore, when called from the EDT, any action provided to the `SwingScheduler`'s `schedule` method (the overload **without** a delay parameter) will execute immediately.

See issue #16.
