### PR TITLE
Automatically subscribe/unsubscribe on the EDT

### DIFF
--- a/src/main/java/rx/subscriptions/SwingSubscriptions.java
+++ b/src/main/java/rx/subscriptions/SwingSubscriptions.java
@@ -29,11 +29,15 @@ public final class SwingSubscriptions {
     }
 
     /**
+     * @deprecated All RxSwing sources now use subscribeOn to subscribe and unsubscribe on
+     * the Swing thread.
+     *
      * Create an Subscription that always runs <code>unsubscribe</code> in the event dispatch thread.
      * 
      * @param unsubscribe
      * @return an Subscription that always runs <code>unsubscribe</code> in the event dispatch thread.
      */
+    @Deprecated
     public static Subscription unsubscribeInEventDispatchThread(final Action0 unsubscribe) {
         return Subscriptions.create(new Action0() {
             @Override

--- a/src/main/java/rx/swing/sources/AbstractButtonSource.java
+++ b/src/main/java/rx/swing/sources/AbstractButtonSource.java
@@ -15,17 +15,17 @@
  */
 package rx.swing.sources;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-
-import javax.swing.AbstractButton;
-
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Action0;
 import rx.observables.SwingObservable;
-import rx.subscriptions.SwingSubscriptions;
+import rx.schedulers.SwingScheduler;
+import rx.subscriptions.Subscriptions;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 public enum AbstractButtonSource { ; // no instances
 
@@ -44,14 +44,14 @@ public enum AbstractButtonSource { ; // no instances
                     }
                 };
                 button.addActionListener(listener);
-                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                subscriber.add(Subscriptions.create(new Action0() {
                     @Override
                     public void call() {
                         button.removeActionListener(listener);
                     }
                 }));
             }
-        });
+        }).subscribeOn(SwingScheduler.getInstance());
     }
 
 }

--- a/src/main/java/rx/swing/sources/AbstractButtonSource.java
+++ b/src/main/java/rx/swing/sources/AbstractButtonSource.java
@@ -19,7 +19,6 @@ import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Action0;
-import rx.observables.SwingObservable;
 import rx.schedulers.SwingScheduler;
 import rx.subscriptions.Subscriptions;
 
@@ -36,7 +35,6 @@ public enum AbstractButtonSource { ; // no instances
         return Observable.create(new OnSubscribe<ActionEvent>() {
             @Override
             public void call(final Subscriber<? super ActionEvent> subscriber) {
-                SwingObservable.assertEventDispatchThread();
                 final ActionListener listener = new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {

--- a/src/main/java/rx/swing/sources/ComponentEventSource.java
+++ b/src/main/java/rx/swing/sources/ComponentEventSource.java
@@ -39,7 +39,6 @@ public enum ComponentEventSource { ; // no instances
         return Observable.create(new OnSubscribe<ComponentEvent>() {
             @Override
             public void call(final Subscriber<? super ComponentEvent> subscriber) {
-                SwingObservable.assertEventDispatchThread();
                 final ComponentListener listener = new ComponentListener() {
                     @Override
                     public void componentHidden(ComponentEvent event) {

--- a/src/main/java/rx/swing/sources/ComponentEventSource.java
+++ b/src/main/java/rx/swing/sources/ComponentEventSource.java
@@ -15,20 +15,20 @@
  */
 package rx.swing.sources;
 
-import static rx.swing.sources.ComponentEventSource.Predicate.RESIZED;
-
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.event.ComponentEvent;
-import java.awt.event.ComponentListener;
-
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Action0;
 import rx.functions.Func1;
 import rx.observables.SwingObservable;
-import rx.subscriptions.SwingSubscriptions;
+import rx.schedulers.SwingScheduler;
+import rx.subscriptions.Subscriptions;
+
+import java.awt.*;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
+
+import static rx.swing.sources.ComponentEventSource.Predicate.RESIZED;
 
 public enum ComponentEventSource { ; // no instances
 
@@ -62,14 +62,14 @@ public enum ComponentEventSource { ; // no instances
                     }
                 };
                 component.addComponentListener(listener);
-                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                subscriber.add(Subscriptions.create(new Action0() {
                     @Override
                     public void call() {
                         component.removeComponentListener(listener);
                     }
                 }));
             }
-        });
+        }).subscribeOn(SwingScheduler.getInstance());
     }
     
     /**

--- a/src/main/java/rx/swing/sources/FocusEventSource.java
+++ b/src/main/java/rx/swing/sources/FocusEventSource.java
@@ -20,7 +20,6 @@ import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Action0;
 import rx.functions.Func1;
-import rx.observables.SwingObservable;
 import rx.schedulers.SwingScheduler;
 import rx.subscriptions.Subscriptions;
 
@@ -37,7 +36,6 @@ public enum FocusEventSource { ; // no instances
         return Observable.create(new OnSubscribe<FocusEvent>() {
             @Override
             public void call(final Subscriber<? super FocusEvent> subscriber) {
-                SwingObservable.assertEventDispatchThread();
                 final FocusListener listener = new FocusListener() {
 
                     @Override

--- a/src/main/java/rx/swing/sources/FocusEventSource.java
+++ b/src/main/java/rx/swing/sources/FocusEventSource.java
@@ -21,7 +21,8 @@ import rx.Subscriber;
 import rx.functions.Action0;
 import rx.functions.Func1;
 import rx.observables.SwingObservable;
-import rx.subscriptions.SwingSubscriptions;
+import rx.schedulers.SwingScheduler;
+import rx.subscriptions.Subscriptions;
 
 import java.awt.*;
 import java.awt.event.FocusEvent;
@@ -50,14 +51,14 @@ public enum FocusEventSource { ; // no instances
                     }
                 };
                 component.addFocusListener(listener);
-                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                subscriber.add(Subscriptions.create(new Action0() {
                     @Override
                     public void call() {
                         component.removeFocusListener(listener);
                     }
                 }));
             }
-        });
+        }).subscribeOn(SwingScheduler.getInstance());
     }
 
     /**

--- a/src/main/java/rx/swing/sources/ItemEventSource.java
+++ b/src/main/java/rx/swing/sources/ItemEventSource.java
@@ -19,7 +19,6 @@ import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Action0;
-import rx.observables.SwingObservable;
 import rx.schedulers.SwingScheduler;
 import rx.subscriptions.Subscriptions;
 
@@ -33,7 +32,6 @@ public enum ItemEventSource { ; // no instances
         return Observable.create(new OnSubscribe<ItemEvent>() {
             @Override
             public void call(final Subscriber<? super ItemEvent> subscriber) {
-                SwingObservable.assertEventDispatchThread();
                 final ItemListener listener = new ItemListener() {
                     @Override
                     public void itemStateChanged( ItemEvent event ) {

--- a/src/main/java/rx/swing/sources/ItemEventSource.java
+++ b/src/main/java/rx/swing/sources/ItemEventSource.java
@@ -15,16 +15,17 @@
  */
 package rx.swing.sources;
 
-import java.awt.ItemSelectable;
-import java.awt.event.ItemEvent;
-import java.awt.event.ItemListener;
-
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Action0;
 import rx.observables.SwingObservable;
-import rx.subscriptions.SwingSubscriptions;
+import rx.schedulers.SwingScheduler;
+import rx.subscriptions.Subscriptions;
+
+import java.awt.*;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 
 public enum ItemEventSource { ; // no instances
 
@@ -33,22 +34,20 @@ public enum ItemEventSource { ; // no instances
             @Override
             public void call(final Subscriber<? super ItemEvent> subscriber) {
                 SwingObservable.assertEventDispatchThread();
-                final ItemListener listener = new ItemListener()
-                {
+                final ItemListener listener = new ItemListener() {
                     @Override
-                    public void itemStateChanged( ItemEvent event )
-                    {
+                    public void itemStateChanged( ItemEvent event ) {
                         subscriber.onNext(event);
                     }
                 };
                 itemSelectable.addItemListener(listener);
-                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                subscriber.add(Subscriptions.create(new Action0() {
                     @Override
                     public void call() {
                         itemSelectable.removeItemListener(listener);
                     }
                 }));
             }
-        });
+        }).subscribeOn(SwingScheduler.getInstance());
     }
 }

--- a/src/main/java/rx/swing/sources/KeyEventSource.java
+++ b/src/main/java/rx/swing/sources/KeyEventSource.java
@@ -21,7 +21,6 @@ import rx.Subscriber;
 import rx.functions.Action0;
 import rx.functions.Func1;
 import rx.functions.Func2;
-import rx.observables.SwingObservable;
 import rx.schedulers.SwingScheduler;
 import rx.subscriptions.Subscriptions;
 
@@ -41,7 +40,6 @@ public enum KeyEventSource { ; // no instances
         return Observable.create(new OnSubscribe<KeyEvent>() {
             @Override
             public void call(final Subscriber<? super KeyEvent> subscriber) {
-                SwingObservable.assertEventDispatchThread();
                 final KeyListener listener = new KeyListener() {
                     @Override
                     public void keyPressed(KeyEvent event) {

--- a/src/main/java/rx/swing/sources/KeyEventSource.java
+++ b/src/main/java/rx/swing/sources/KeyEventSource.java
@@ -15,13 +15,6 @@
  */
 package rx.swing.sources;
 
-import java.awt.Component;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
@@ -29,7 +22,15 @@ import rx.functions.Action0;
 import rx.functions.Func1;
 import rx.functions.Func2;
 import rx.observables.SwingObservable;
-import rx.subscriptions.SwingSubscriptions;
+import rx.schedulers.SwingScheduler;
+import rx.subscriptions.Subscriptions;
+
+import java.awt.*;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 public enum KeyEventSource { ; // no instances
 
@@ -59,14 +60,14 @@ public enum KeyEventSource { ; // no instances
                 };
                 component.addKeyListener(listener);
 
-                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                subscriber.add(Subscriptions.create(new Action0() {
                     @Override
                     public void call() {
                         component.removeKeyListener(listener);
                     }
                 }));
             }
-        });
+        }).subscribeOn(SwingScheduler.getInstance());
     }
 
     /**

--- a/src/main/java/rx/swing/sources/MouseEventSource.java
+++ b/src/main/java/rx/swing/sources/MouseEventSource.java
@@ -15,17 +15,17 @@
  */
 package rx.swing.sources;
 
-import java.awt.Component;
-import java.awt.Point;
-import java.awt.event.*;
-
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Action0;
 import rx.functions.Func2;
 import rx.observables.SwingObservable;
-import rx.subscriptions.SwingSubscriptions;
+import rx.schedulers.SwingScheduler;
+import rx.subscriptions.Subscriptions;
+
+import java.awt.*;
+import java.awt.event.*;
 
 public enum MouseEventSource {
     ; // no instances
@@ -66,14 +66,14 @@ public enum MouseEventSource {
                 };
                 component.addMouseListener(listener);
 
-                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                subscriber.add(Subscriptions.create(new Action0() {
                     @Override
                     public void call() {
                         component.removeMouseListener(listener);
                     }
                 }));
             }
-        });
+        }).subscribeOn(SwingScheduler.getInstance());
     }
 
     /**
@@ -97,14 +97,14 @@ public enum MouseEventSource {
                 };
                 component.addMouseMotionListener(listener);
 
-                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                subscriber.add(Subscriptions.create(new Action0() {
                     @Override
                     public void call() {
                         component.removeMouseMotionListener(listener);
                     }
                 }));
             }
-        });
+        }).subscribeOn(SwingScheduler.getInstance());
     }
 
     public static Observable<MouseWheelEvent> fromMouseWheelEvents(final Component component){
@@ -119,14 +119,14 @@ public enum MouseEventSource {
                 };
                 component.addMouseWheelListener(listener);
 
-                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                subscriber.add(Subscriptions.create(new Action0() {
                     @Override
                     public void call() {
                         component.removeMouseWheelListener(listener);
                     }
                 }));
             }
-        });
+        }).subscribeOn(SwingScheduler.getInstance());
     }
 
     /**
@@ -139,7 +139,7 @@ public enum MouseEventSource {
             public Point call(MouseEvent ev1, MouseEvent ev2) {
                 return new Point(ev2.getX() - ev1.getX(), ev2.getY() - ev1.getY());
             }
-        });
+        }).subscribeOn(SwingScheduler.getInstance());
     }
 
 }

--- a/src/main/java/rx/swing/sources/MouseEventSource.java
+++ b/src/main/java/rx/swing/sources/MouseEventSource.java
@@ -20,7 +20,6 @@ import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Action0;
 import rx.functions.Func2;
-import rx.observables.SwingObservable;
 import rx.schedulers.SwingScheduler;
 import rx.subscriptions.Subscriptions;
 
@@ -37,7 +36,6 @@ public enum MouseEventSource {
         return Observable.create(new OnSubscribe<MouseEvent>() {
             @Override
             public void call(final Subscriber<? super MouseEvent> subscriber) {
-                SwingObservable.assertEventDispatchThread();
                 final MouseListener listener = new MouseListener() {
                     @Override
                     public void mouseClicked(MouseEvent event) {
@@ -83,7 +81,6 @@ public enum MouseEventSource {
         return Observable.create(new OnSubscribe<MouseEvent>() {
             @Override
             public void call(final Subscriber<? super MouseEvent> subscriber) {
-                SwingObservable.assertEventDispatchThread();
                 final MouseMotionListener listener = new MouseMotionListener() {
                     @Override
                     public void mouseDragged(MouseEvent event) {

--- a/src/main/java/rx/swing/sources/PropertyChangeEventSource.java
+++ b/src/main/java/rx/swing/sources/PropertyChangeEventSource.java
@@ -19,7 +19,6 @@ import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Action0;
-import rx.observables.SwingObservable;
 import rx.schedulers.SwingScheduler;
 import rx.subscriptions.Subscriptions;
 
@@ -33,7 +32,6 @@ public enum PropertyChangeEventSource { ; // no instances
         return Observable.create(new OnSubscribe<PropertyChangeEvent>() {
             @Override
             public void call(final Subscriber<? super PropertyChangeEvent> subscriber) {
-                SwingObservable.assertEventDispatchThread();
                 final PropertyChangeListener listener = new PropertyChangeListener() {
                     @Override
                     public void propertyChange(PropertyChangeEvent event) {

--- a/src/main/java/rx/swing/sources/PropertyChangeEventSource.java
+++ b/src/main/java/rx/swing/sources/PropertyChangeEventSource.java
@@ -15,16 +15,17 @@
  */
 package rx.swing.sources;
 
-import java.awt.Component;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-
 import rx.Observable;
 import rx.Observable.OnSubscribe;
 import rx.Subscriber;
 import rx.functions.Action0;
 import rx.observables.SwingObservable;
-import rx.subscriptions.SwingSubscriptions;
+import rx.schedulers.SwingScheduler;
+import rx.subscriptions.Subscriptions;
+
+import java.awt.*;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 
 public enum PropertyChangeEventSource { ; // no instances
 
@@ -40,13 +41,13 @@ public enum PropertyChangeEventSource { ; // no instances
                     }
                 };
                 component.addPropertyChangeListener(listener);
-                subscriber.add(SwingSubscriptions.unsubscribeInEventDispatchThread(new Action0() {
+                subscriber.add(Subscriptions.create(new Action0() {
                     @Override
                     public void call() {
                         component.removePropertyChangeListener(listener);
                     }
                 }));
             }
-        });
+        }).subscribeOn(SwingScheduler.getInstance());
     }
 }


### PR DESCRIPTION
Made all event sources automatically subscribe & unsubscribe
on the Swing thread. Previously, only unsubscribe was automatically
placed on the EDT.

This closes issue #3.
