### PR TITLE
[do not yet merge] ChangeEventSource & fromChangeEvents

### DIFF
--- a/src/main/java/rx/swing/sources/ChangeEventSource.java
+++ b/src/main/java/rx/swing/sources/ChangeEventSource.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.swing.sources;
+
+import rx.Subscriber;
+
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+/**
+ * Note: There's no common supertype of all components which have add/removeChangeListener
+ * methods, so we cannot implement add/removeListenerForComponent methods here, so this
+ * class has to remain abstract.
+ */
+public abstract class ChangeEventSource extends EventSource<ChangeEvent, ChangeListener> {
+
+    @Override
+    public ChangeListener createListenerFor(final Subscriber<? super ChangeEvent> subscriber) {
+        return new ChangeListener() {
+            @Override
+            public void stateChanged(ChangeEvent e) {
+                subscriber.onNext(e);
+            }
+        };
+    }
+}

--- a/src/main/java/rx/swing/sources/EventSource.java
+++ b/src/main/java/rx/swing/sources/EventSource.java
@@ -1,0 +1,28 @@
+package rx.swing.sources;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Action0;
+import rx.subscriptions.Subscriptions;
+
+public abstract class EventSource<Event, Listener> implements Observable.OnSubscribe<Event> {
+
+    protected abstract Listener createListenerFor(Subscriber<? super Event> subscriber);
+
+    protected abstract void addListenerToComponent(Listener listener);
+
+    protected abstract void removeListenerFromComponent(Listener listener);
+
+    @Override
+    public void call(final Subscriber<? super Event> subscriber) {
+        final Listener listener = createListenerFor(subscriber);
+        addListenerToComponent(listener);
+        subscriber.add(Subscriptions.create(new Action0() {
+            @Override
+            public void call() {
+                removeListenerFromComponent(listener);
+            }
+        }));
+    }
+
+}


### PR DESCRIPTION
Here's how I would add a `ChangeEventSource` and `SwingObservable.fromChangeEvents(...)` methods.

The problem is that the many Swing classes which have `addChangeListener` and `removeChangeListener` methods don't implement a common interface or super class, so we need to write a separate `fromChangeEvents` overload for each such Swing class.

So the goal is to have no code duplication except at the place where we have to show to the Java compiler that the Swing class in question indeed has `addChangeListener` and `removeChangeListener` methods. This PR gives one way of achieving this, comments/feedback are welcome ;-)

Note that this PR is not yet complete: It has no tests yet, needs more `fromChangeEvents` overloads, and probably also some doc improvements. I don't have time to continue on this right now, but everyone please feel free to branch from here and continue ;-)
