### PR TITLE
Support for ChangeListener

### DIFF
--- a/src/main/java/rx/observables/SwingObservable.java
+++ b/src/main/java/rx/observables/SwingObservable.java
@@ -20,9 +20,9 @@ import java.awt.event.*;
 import java.beans.PropertyChangeEvent;
 import java.util.Set;
 
-import javax.swing.AbstractButton;
-import javax.swing.ListSelectionModel;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
+import javax.swing.colorchooser.ColorSelectionModel;
+import javax.swing.event.ChangeEvent;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.text.Document;
@@ -282,6 +282,148 @@ public enum SwingObservable { ; // no instances
                 return eventTypes.contains(event.getType());
             }
         });
+    }
+
+    /**
+     * Creates an observable corresponding to change events (e.g. tab selection).
+     * <p/>
+     * For more info to change listeners and events see <a href="https://docs.oracle.com/javase/tutorial/uiswing/events/changelistener.html">
+     * How to Write a Change Listener</a>.
+     *
+     * @param component
+     * 		The component to register the observable for.
+     * @return Observable emitting the change events.
+     */
+    public static Observable<ChangeEvent> fromChangeEvents(JTabbedPane component) {
+        return ChangeEventSource.fromChangeEventsOf(component);
+    }
+
+    /**
+     * Creates an observable corresponding to change events (e.g. value changes).
+     * <p/>
+     * For more info to change listeners and events see <a href="https://docs.oracle.com/javase/tutorial/uiswing/events/changelistener.html">
+     * How to Write a Change Listener</a>.
+     *
+     * @param component
+     * 		The component to register the observable for.
+     * @return Observable emitting the change events.
+     */
+    public static Observable<ChangeEvent> fromChangeEvents(JSlider component) {
+        return ChangeEventSource.fromChangeEventsOf(component);
+    }
+
+    /**
+     * Creates an observable corresponding to change events (e.g. value changes).
+     * <p/>
+     * For more info to change listeners and events see <a href="https://docs.oracle.com/javase/tutorial/uiswing/events/changelistener.html">
+     * How to Write a Change Listener</a> and <a href="https://docs.oracle.com/javase/tutorial/uiswing/components/spinner.html#change">
+     * How to Use Spinners</a>.
+     *
+     * @param component
+     * 		The component to register the observable for.
+     * @return Observable emitting the change events.
+     */
+    public static Observable<ChangeEvent> fromChangeEvents(JSpinner component) {
+        return ChangeEventSource.fromChangeEventsOf(component);
+    }
+
+    /**
+     * Creates an observable corresponding to change events (e.g. value changes).
+     * <p/>
+     * For more info to change listeners and events see <a href="https://docs.oracle.com/javase/tutorial/uiswing/events/changelistener.html">
+     * How to Write a Change Listener</a> and <a href="https://docs.oracle.com/javase/tutorial/uiswing/components/spinner.html#change">
+     * How to Use Spinners</a>.
+     *
+     * @param spinnerModel
+     * 		The spinnerModel to register the observable for.
+     * @return Observable emitting the change events.
+     */
+    public static Observable<ChangeEvent> fromChangeEvents(SpinnerModel spinnerModel) {
+        return ChangeEventSource.fromChangeEventsOf(spinnerModel);
+    }
+
+    /**
+     * Creates an observable corresponding to change events (e.g. button clicks changes).
+     * <p/>
+     * For more info to change listeners and events see <a href="https://docs.oracle.com/javase/tutorial/uiswing/events/changelistener.html">
+     * How to Write a Change Listener</a>.
+     *
+     * @param component
+     * 		The component to register the observable for.
+     * @return Observable emitting the change events.
+     */
+    public static Observable<ChangeEvent> fromChangeEvents(AbstractButton component) {
+        return ChangeEventSource.fromChangeEventsOf(component);
+    }
+
+    /**
+     * Creates an observable corresponding to change events (e.g. button clicks changes).
+     * <p/>
+     * For more info to change listeners and events see <a href="https://docs.oracle.com/javase/tutorial/uiswing/events/changelistener.html">
+     * How to Write a Change Listener</a>.
+     *
+     * @param buttonModel
+     * 		The buttonModel to register the observable for.
+     * @return Observable emitting the change events.
+     */
+    public static Observable<ChangeEvent> fromChangeEvents(ButtonModel buttonModel) {
+        return ChangeEventSource.fromChangeEventsOf(buttonModel);
+    }
+
+    /**
+     * Creates an observable corresponding to change events (e.g. scrolling).
+     * <p/>
+     * For more info to change listeners and events see <a href="https://docs.oracle.com/javase/tutorial/uiswing/events/changelistener.html">
+     * How to Write a Change Listener</a>.
+     *
+     * @param component
+     * 		The component to register the observable for.
+     * @return Observable emitting the change events.
+     */
+    public static Observable<ChangeEvent> fromChangeEvents(JViewport component) {
+        return ChangeEventSource.fromChangeEventsOf(component);
+    }
+
+    /**
+     * Creates an observable corresponding to change events (e.g. from a color chooser).
+     * <p/>
+     * For more info to change listeners and events see <a href="https://docs.oracle.com/javase/tutorial/uiswing/events/changelistener.html">
+     * How to Write a Change Listener</a>.
+     *
+     * @param colorSelectionModel
+     * 		The colorSelectionModel to register the observable for.
+     * @return Observable emitting the change events.
+     */
+    public static Observable<ChangeEvent> fromChangeEvents(ColorSelectionModel colorSelectionModel) {
+        return ChangeEventSource.fromChangeEventsOf(colorSelectionModel);
+    }
+
+    /**
+     * Creates an observable corresponding to change events (e.g. progressbar value changes).
+     * <p/>
+     * For more info to change listeners and events see <a href="https://docs.oracle.com/javase/tutorial/uiswing/events/changelistener.html">
+     * How to Write a Change Listener</a>.
+     *
+     * @param component
+     * 		The component to register the observable for.
+     * @return Observable emitting the change events.
+     */
+    public static Observable<ChangeEvent> fromChangeEvents(JProgressBar component) {
+        return ChangeEventSource.fromChangeEventsOf(component);
+    }
+
+    /**
+     * Creates an observable corresponding to change events (e.g. progressbar value changes).
+     * <p/>
+     * For more info to change listeners and events see <a href="https://docs.oracle.com/javase/tutorial/uiswing/events/changelistener.html">
+     * How to Write a Change Listener</a>.
+     *
+     * @param boundedRangeModel
+     * 		The boundedRangeModel to register the observable for.
+     * @return Observable emitting the change events.
+     */
+    public static Observable<ChangeEvent> fromChangeEvents(BoundedRangeModel boundedRangeModel) {
+        return ChangeEventSource.fromChangeEventsOf(boundedRangeModel);
     }
 
     /**

--- a/src/main/java/rx/swing/sources/ChangeEventSource.java
+++ b/src/main/java/rx/swing/sources/ChangeEventSource.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.swing.sources;
+
+import rx.Observable;
+import rx.Observable.OnSubscribe;
+import rx.Subscriber;
+import rx.functions.Action0;
+import rx.schedulers.SwingScheduler;
+import rx.subscriptions.Subscriptions;
+
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+public enum ChangeEventSource { ; // no instances
+
+	private static final String ADD_CHANGE_LISTENER_METHOD_NAME = "addChangeListener";
+	private static final String REMOVE_CHANGE_LISTENER_METHOD_NAME = "removeChangeListener";
+
+	/**
+	 * Creates an observable corresponding to change events (e.g. progressbar value changes).
+	 *
+	 * Due to the lack of a common interface in Java (up to at least version 8), the implementation
+	 * is generic and uses internally reflection to add and remove it's {@link ChangeListener}'s.
+	 * The contract is therefor that the given parameter object MUST have the typical two public methods "addChangeListener"
+	 * (like {@link javax.swing.JProgressBar#addChangeListener(ChangeListener)}) and "removeChangeListener"
+	 * (like {@link javax.swing.JProgressBar#removeChangeListener(ChangeListener)}).
+	 *
+	 * For more info to change listeners and events see <a href="https://docs.oracle.com/javase/tutorial/uiswing/events/changelistener.html">
+	 * How to Write a Change Listener</a>.
+	 *
+	 * @param changeEventSource
+	 * 		The object to register the observable for.
+	 * @return Observable emitting the change events.
+	 * @throws IllegalArgumentException if the given parameter object has not the needed signature
+	 */
+	public static Observable<ChangeEvent> fromChangeEventsOf(final Object changeEventSource) {
+		checkHasChangeListenerSupport(changeEventSource);
+		return Observable.create(new OnSubscribe<ChangeEvent>() {
+			@Override
+			public void call(final Subscriber<? super ChangeEvent> subscriber) {
+				final ChangeListener listener = new ChangeListener() {
+					@Override
+					public void stateChanged(final ChangeEvent event) {
+						subscriber.onNext(event);
+					}
+				};
+				addChangeListener(changeEventSource, listener);
+				subscriber.add(Subscriptions.create(new Action0() {
+					@Override
+					public void call() {
+						removeChangeListener(changeEventSource, listener);
+					}
+				}));
+			}
+		}).subscribeOn(SwingScheduler.getInstance())
+				.unsubscribeOn(SwingScheduler.getInstance());
+	}
+
+	private static void checkHasChangeListenerSupport(Object object) {
+		checkPublicMethodExists(object, ADD_CHANGE_LISTENER_METHOD_NAME, ChangeListener.class);
+		checkPublicMethodExists(object, REMOVE_CHANGE_LISTENER_METHOD_NAME, ChangeListener.class);
+	}
+
+	private static void checkPublicMethodExists(Object object, String methodName, Class<?>... parameterTypes) {
+		try {
+			Method method = object.getClass().getMethod(methodName, parameterTypes);
+			if (!Modifier.isPublic(method.getModifiers())) {
+				throw new IllegalArgumentException(
+						"Class '" + object.getClass().getName() + "' has not the expected signature to support change listeners in "
+								+ ChangeEventSource.class.getName() + ". " + methodName + " is not accessible.");
+			}
+		} catch (NoSuchMethodException e) {
+			throw new IllegalArgumentException("Class '" + object.getClass().getName() + "' has not the expected signature to support change listeners in " + ChangeEventSource.class.getName(), e);
+		}
+	}
+
+	private static void addChangeListener(Object object, ChangeListener changeListener) {
+		callChangeListenerMethodViaReflection(object, ADD_CHANGE_LISTENER_METHOD_NAME, changeListener);
+	}
+
+	private static void removeChangeListener(Object object, ChangeListener changeListener) {
+		callChangeListenerMethodViaReflection(object, REMOVE_CHANGE_LISTENER_METHOD_NAME, changeListener);
+	}
+
+	private static void callChangeListenerMethodViaReflection(Object object,
+	                                                          String methodName,
+	                                                          ChangeListener changeListener) {
+		try {
+			object.getClass().getMethod(methodName, ChangeListener.class).invoke(object, changeListener);
+		} catch (IllegalAccessException e) {
+			throw new IllegalArgumentException("Call of " + methodName + " via reflection failed. Does class " + object.getClass().getName() + " support change listeners?", e);
+		} catch (InvocationTargetException e) {
+			throw new IllegalArgumentException("Call of " + methodName + " via reflection failed.", e);
+		} catch (NoSuchMethodException e) {
+			throw new IllegalArgumentException("Call of " + methodName + " via reflection failed. Does class " + object.getClass().getName() + " support change listeners?", e);
+		}
+	}
+}

--- a/src/test/java/rx/swing/sources/ChangeEventSourceTest.java
+++ b/src/test/java/rx/swing/sources/ChangeEventSourceTest.java
@@ -1,0 +1,480 @@
+/**
+ * Copyright 2015 Netflix, Inc.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.swing.sources;
+
+import org.junit.Test;
+import rx.Subscription;
+import rx.functions.Action0;
+import rx.observers.TestSubscriber;
+
+import javax.swing.*;
+import javax.swing.colorchooser.ColorSelectionModel;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import java.awt.*;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ChangeEventSourceTest {
+
+	@Test
+	public void jTabbedPane_observingSelectionEvents() throws Throwable {
+		SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+			@Override
+			public void call() {
+				TestSubscriber<ChangeEvent> testSubscriber = TestSubscriber.create();
+
+				JTabbedPane tabbedPane = createTabbedPane();
+				ChangeEventSource.fromChangeEventsOf(tabbedPane)
+						.subscribe(testSubscriber);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertNoValues();
+
+				tabbedPane.setSelectedIndex(2);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(1);
+
+				assertEquals(tabbedPane, testSubscriber.getOnNextEvents().get(0).getSource());
+
+				tabbedPane.setSelectedIndex(0);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(2);
+
+				assertEquals(tabbedPane, testSubscriber.getOnNextEvents().get(1).getSource());
+			}
+		}).awaitTerminal();
+	}
+
+	@Test
+	public void jSlider_observingValueChangeEvents() throws Throwable {
+		SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+			@Override
+			public void call() {
+				TestSubscriber<ChangeEvent> testSubscriber = TestSubscriber.create();
+
+				JSlider slider = new JSlider();
+				slider.setMinimum(0);
+				slider.setMaximum(10);
+				ChangeEventSource.fromChangeEventsOf(slider)
+						.subscribe(testSubscriber);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertNoValues();
+
+				slider.setValue(5);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(1);
+
+				assertEquals(slider, testSubscriber.getOnNextEvents().get(0).getSource());
+
+				slider.setValue(8);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(2);
+
+				assertEquals(slider, testSubscriber.getOnNextEvents().get(1).getSource());
+			}
+		}).awaitTerminal();
+	}
+
+	@Test
+	public void jSpinner_observingValueChangeEvents() throws Throwable {
+		SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+			@Override
+			public void call() {
+				TestSubscriber<ChangeEvent> testSubscriber = TestSubscriber.create();
+
+				JSpinner spinner = createSpinner();
+				ChangeEventSource.fromChangeEventsOf(spinner)
+						.subscribe(testSubscriber);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertNoValues();
+
+				spinner.setValue("2015");
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(1);
+
+				assertEquals(spinner, testSubscriber.getOnNextEvents().get(0).getSource());
+
+				spinner.setValue("2016");
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(2);
+
+				assertEquals(spinner, testSubscriber.getOnNextEvents().get(1).getSource());
+			}
+		}).awaitTerminal();
+	}
+
+	@Test
+	public void spinnerModel_observingValueChangeEvents() throws Throwable {
+		SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+			@Override
+			public void call() {
+				TestSubscriber<ChangeEvent> testSubscriber = TestSubscriber.create();
+
+				JSpinner spinner = createSpinner();
+				final SpinnerModel spinnerModel = spinner.getModel();
+				ChangeEventSource.fromChangeEventsOf(spinnerModel)
+						.subscribe(testSubscriber);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertNoValues();
+
+				spinner.setValue("2015");
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(1);
+
+				assertEquals(spinnerModel, testSubscriber.getOnNextEvents().get(0).getSource());
+
+				spinner.setValue("2016");
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(2);
+
+				assertEquals(spinnerModel, testSubscriber.getOnNextEvents().get(1).getSource());
+			}
+		}).awaitTerminal();
+	}
+
+	@Test
+	public void abstractButton_observingPressedEvents() throws Throwable {
+		SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+			@Override
+			public void call() {
+				TestSubscriber<ChangeEvent> testSubscriber = TestSubscriber.create();
+
+				AbstractButton button = new JButton("Click me");
+				ChangeEventSource.fromChangeEventsOf(button)
+						.subscribe(testSubscriber);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertNoValues();
+
+				button.getModel().setPressed(true);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(1);
+
+				assertEquals(button, testSubscriber.getOnNextEvents().get(0).getSource());
+
+				button.getModel().setPressed(false);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(2);
+
+				assertEquals(button, testSubscriber.getOnNextEvents().get(1).getSource());
+			}
+		}).awaitTerminal();
+	}
+
+	@Test
+	public void buttonModel_observingPressedEvents() throws Throwable {
+		SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+			@Override
+			public void call() {
+				TestSubscriber<ChangeEvent> testSubscriber = TestSubscriber.create();
+
+				AbstractButton button = new JButton("Click me");
+				final ButtonModel buttonModel = button.getModel();
+				ChangeEventSource.fromChangeEventsOf(buttonModel)
+						.subscribe(testSubscriber);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertNoValues();
+
+				buttonModel.setPressed(true);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(1);
+
+				assertEquals(buttonModel, testSubscriber.getOnNextEvents().get(0).getSource());
+
+				buttonModel.setPressed(false);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(2);
+
+				assertEquals(buttonModel, testSubscriber.getOnNextEvents().get(1).getSource());
+			}
+		}).awaitTerminal();
+	}
+
+	@Test
+	public void jViewPort_observingScrollEvents() throws Throwable {
+		SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+			@Override
+			public void call() {
+				TestSubscriber<ChangeEvent> testSubscriber = TestSubscriber.create();
+
+				JTable table = new JTable(1000, 5);
+				JScrollPane scrollPane = new JScrollPane(table);
+				final JViewport viewPort = scrollPane.getViewport();
+				ChangeEventSource.fromChangeEventsOf(viewPort)
+						.subscribe(testSubscriber);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertNoValues();
+
+				// scoll down
+				table.scrollRectToVisible(table.getCellRect(table.getModel().getRowCount() - 1, 0, false));
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(1);
+
+				assertEquals(viewPort, testSubscriber.getOnNextEvents().get(0).getSource());
+
+				// scoll up
+				table.scrollRectToVisible(table.getCellRect(0, 0, false));
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(2);
+
+				assertEquals(viewPort, testSubscriber.getOnNextEvents().get(1).getSource());
+			}
+		}).awaitTerminal();
+	}
+
+	@Test
+	public void colorSelectionModel_observingColorChooserEvents() throws Throwable {
+		SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+			@Override
+			public void call() {
+				TestSubscriber<ChangeEvent> testSubscriber = TestSubscriber.create();
+
+				JColorChooser colorChooser = new JColorChooser();
+				final ColorSelectionModel colorSelectionModel = colorChooser.getSelectionModel();
+				ChangeEventSource.fromChangeEventsOf(colorSelectionModel)
+						.subscribe(testSubscriber);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertNoValues();
+
+				colorChooser.setColor(Color.BLUE);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(1);
+
+				assertEquals(colorSelectionModel, testSubscriber.getOnNextEvents().get(0).getSource());
+
+				colorChooser.setColor(Color.GREEN);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(2);
+
+				assertEquals(colorSelectionModel, testSubscriber.getOnNextEvents().get(1).getSource());
+			}
+		}).awaitTerminal();
+	}
+
+	@Test
+	public void jProgressBar_observingProgressEvents() throws Throwable {
+		SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+			@Override
+			public void call() {
+				TestSubscriber<ChangeEvent> testSubscriber = TestSubscriber.create();
+
+				JProgressBar progressBar = new JProgressBar();
+				progressBar.setMinimum(0);
+				progressBar.setMaximum(10);
+				ChangeEventSource.fromChangeEventsOf(progressBar)
+						.subscribe(testSubscriber);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertNoValues();
+
+				progressBar.setValue(1);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(1);
+
+				assertEquals(progressBar, testSubscriber.getOnNextEvents().get(0).getSource());
+
+				progressBar.setValue(2);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(2);
+
+				assertEquals(progressBar, testSubscriber.getOnNextEvents().get(1).getSource());
+			}
+		}).awaitTerminal();
+	}
+
+	@Test
+	public void boundedRangeModel_observingProgressEvents() throws Throwable {
+		SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+			@Override
+			public void call() {
+				TestSubscriber<ChangeEvent> testSubscriber = TestSubscriber.create();
+
+				JProgressBar progressBar = new JProgressBar();
+				progressBar.setMinimum(0);
+				progressBar.setMaximum(10);
+				final BoundedRangeModel boundedRangeModel = progressBar.getModel();
+				ChangeEventSource.fromChangeEventsOf(boundedRangeModel)
+						.subscribe(testSubscriber);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertNoValues();
+
+				progressBar.setValue(1);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(1);
+
+				assertEquals(boundedRangeModel, testSubscriber.getOnNextEvents().get(0).getSource());
+
+				progressBar.setValue(2);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertValueCount(2);
+
+				assertEquals(boundedRangeModel, testSubscriber.getOnNextEvents().get(1).getSource());
+			}
+		}).awaitTerminal();
+	}
+
+	@Test
+	public void unsubscribeRemovesRowSelectionListener() throws Throwable {
+		SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+			@Override
+			public void call() {
+				TestSubscriber<ChangeEvent> testSubscriber = TestSubscriber.create();
+
+				JTabbedPane tabbedPane = createTabbedPane();
+				int numberOfListenersBefore = tabbedPane.getChangeListeners().length;
+
+				Subscription sub = ChangeEventSource.fromChangeEventsOf(tabbedPane)
+						.subscribe(testSubscriber);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertNoValues();
+
+				sub.unsubscribe();
+
+				testSubscriber.assertUnsubscribed();
+
+				tabbedPane.setSelectedIndex(2);
+
+				testSubscriber.assertNoErrors();
+				testSubscriber.assertNoValues();
+
+				assertEquals(numberOfListenersBefore, tabbedPane.getChangeListeners().length);
+			}
+		}).awaitTerminal();
+	}
+
+	@Test
+	public void fromChangeEventsOf_usingObjectWithoutExpectedChangeListenerSupport_failsFastWithException() throws Throwable {
+		SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+			@Override
+			public void call() {
+				try {
+					ChangeEventSource.fromChangeEventsOf("doesNotSupportChangeListeners").subscribe(TestSubscriber.create());
+					fail(IllegalArgumentException.class.getSimpleName() + " expected");
+				} catch (IllegalArgumentException ex) {
+					assertEquals("Class 'java.lang.String' has not the expected signature to support change listeners in rx.swing.sources.ChangeEventSource",
+							ex.getMessage());
+				}
+
+				Object changeEventSource = null;
+				try {
+					changeEventSource = new Object() {
+						private void addChangeListener(ChangeListener changeListener) {/* no-op */ }
+
+						private void removeChangeListener(ChangeListener changeListener) {/* no-op */ }
+
+						@Override
+						public String toString() {
+							return "hasWrongMethodModifiers";
+						}
+					};
+					ChangeEventSource.fromChangeEventsOf(changeEventSource).subscribe(TestSubscriber.create());
+					fail(IllegalArgumentException.class.getSimpleName() + " expected");
+				} catch (IllegalArgumentException ex) {
+					assertEquals("Class '" + changeEventSource.getClass().getName() + "' has not the expected signature to support change listeners in rx.swing.sources.ChangeEventSource",
+							ex.getMessage());
+				}
+			}
+		}).awaitTerminal();
+	}
+
+	@Test
+	public void issuesWithAddingChangeListenerOnSubscriptionArePropagatedAsError() throws Throwable {
+		SwingTestHelper.create().runInEventDispatchThread(new Action0() {
+
+			@Override
+			public void call() {
+				TestSubscriber<ChangeEvent> testSubscriber = TestSubscriber.create();
+
+				JProgressBar brokenProgressBarSubClass = new JProgressBar() {
+					@Override
+					public void addChangeListener(ChangeListener listener) {
+						if (listener.getClass().getName().contains(ChangeEventSource.class.getSimpleName())) {
+							throw new RuntimeException("Totally broken");
+						}
+					}
+				};
+				ChangeEventSource.fromChangeEventsOf(brokenProgressBarSubClass)
+						.subscribe(testSubscriber);
+
+				testSubscriber.assertNoValues();
+
+				List<Throwable> onErrorEvents = testSubscriber.getOnErrorEvents();
+				assertEquals(1, onErrorEvents.size());
+				assertTrue(onErrorEvents.get(0) instanceof RuntimeException);
+				assertEquals("Call of addChangeListener via reflection failed.", onErrorEvents.get(0).getMessage());
+				assertEquals(InvocationTargetException.class, onErrorEvents.get(0).getCause().getClass());
+			}
+		}).awaitTerminal();
+	}
+
+	private static JTabbedPane createTabbedPane() {
+		final JTabbedPane tabbedPane = new JTabbedPane();
+		tabbedPane.addTab("tab1", new JPanel());
+		tabbedPane.addTab("tab2", new JPanel());
+		tabbedPane.addTab("tab3", new JPanel());
+		return tabbedPane;
+	}
+
+	private static JSpinner createSpinner() {
+		List<String> yearStrings = Arrays.asList("2014", "2015", "2016");
+		SpinnerListModel spinnerListModel = new SpinnerListModel(yearStrings);
+		return new JSpinner(spinnerListModel);
+	}
+}


### PR DESCRIPTION
Hi @mikebaum,

I implemented support for ChangeListener's for: JTabbedPane,  JSlider, JSpinner, SpinnerModel, AbstractButton, ButtonModel and JViewport. Would be nice to have that soon in RxSwing.

About the implementation:
Since there is no "common" interface for the two common methods _addChangeListener_ and _removeChangeListener_ of classes like JTabbedPane, JSlider, etc... I decided to use internally _reflection_ to avoid duplicated code. Using reflection gives a little performance penalty, but in the seldom case of registering / unregistering change listeners, this should not be an issue.

I know this PR is competing the work and the two PR's from @samuelgruetter. It's based on the _typical style_ of RxSwing and does not introduce refactorings, but comes "ready to use" with tests. So it's a quick solution to have support for ChangeListener _now_, without considering design improvements. What do you @samuelgruetter and @mikebaum think?

Best regards from Lucerne in Switzerland,
Peti
